### PR TITLE
Fix NameError in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,5 @@ setup(
         'Natural Language :: English',
         'Topic :: Software Development :: Libraries',
         ],
-    keywords=['mozilla', 'basket'],
-    **extra_setup
+    keywords=['mozilla', 'basket']
 )


### PR DESCRIPTION
This fixes the NameError in setup.py. I looked at the history and it looks like it was just added as a copy-paste error.

r?
