### PR TITLE
Handle Timeout from request

### DIFF
--- a/basket/base.py
+++ b/basket/base.py
@@ -57,6 +57,8 @@ def request(method, action, data=None, token=None, params=None):
                                timeout=10)
     except requests.exceptions.ConnectionError:
         raise BasketException("Error connecting to basket")
+    except requests.exceptions.Timeout:
+        raise BasketException("Timeout connecting to basket")
     return parse_response(res)
 
 


### PR DESCRIPTION
The requests library can fail the request with a Timeout exception.
If the user of basket-client wants to catch BasketException when
there's an error on its request, it probably expects timeouts to be
included, and not to have to explicitly catch the request library's
Timeout exception. So catch that in basket-client and raise the
expected BasketException.
