### PR TITLE
Bug 901541 - newsletter recovery message

### DIFF
--- a/basket/__init__.py
+++ b/basket/__init__.py
@@ -1,4 +1,5 @@
 """A Python client for Mozilla's basket service."""
 
-from base import (BasketException, confirm, debug_user, get_newsletters,
-                  request, send_sms, subscribe, unsubscribe, update_user, user)
+from base import (BasketException, BasketNetworkException, confirm, debug_user,
+                  get_newsletters, request, send_recovery_message, send_sms,
+                  subscribe, unsubscribe, update_user, user)

--- a/basket/base.py
+++ b/basket/base.py
@@ -28,6 +28,10 @@ class BasketException(Exception):
         super(BasketException, self).__init__(*args, **kwargs)
 
 
+class BasketNetworkException(BasketException):
+    """Used on error connecting to basket"""
+
+
 def basket_url(method, token=None):
     """Form a basket API url. If the request requires a user-specific
     token, it is suffixed as the last part of the URL."""
@@ -69,9 +73,9 @@ def request(method, action, data=None, token=None, params=None):
                                params=params,
                                timeout=10)
     except requests.exceptions.ConnectionError:
-        raise BasketException("Error connecting to basket")
+        raise BasketNetworkException("Error connecting to basket")
     except requests.exceptions.Timeout:
-        raise BasketException("Timeout connecting to basket")
+        raise BasketNetworkException("Timeout connecting to basket")
     return parse_response(res)
 
 
@@ -142,6 +146,11 @@ def debug_user(email, supertoken):
     return request('get', 'debug-user',
                    params={'email': email,
                            'supertoken': supertoken})
+
+
+def send_recovery_message(email):
+    """Send recovery message for this email"""
+    return request('post', 'recover', data={'email': email})
 
 
 def get_newsletters():

--- a/basket/tests.py
+++ b/basket/tests.py
@@ -5,7 +5,8 @@ from requests.exceptions import ConnectionError, Timeout
 from mock import Mock, patch
 
 from basket import (BasketException, confirm, debug_user, get_newsletters,
-                    request, subscribe, unsubscribe, update_user, user)
+                    request, send_recovery_message, subscribe, unsubscribe,
+                    update_user, user)
 from basket.base import basket_url, parse_response
 
 
@@ -279,3 +280,15 @@ class TestBasketClient(TestCase):
             result = confirm(token)
         request_call.assert_called_with('post', 'confirm', token=token)
         self.assertEqual(request_call.return_value, result)
+
+    def test_send_recovery_email(self):
+        """
+        send_recovery_email() passes the expected args to request,
+        and returns the result.
+        """
+        email = "dude@example.com"
+        with patch('basket.base.request', autospec=True) as mock_request:
+            result = send_recovery_message(email)
+        data = {'email': email}
+        mock_request.assert_called_with('post', 'recovery', data=data)
+        self.assertEqual(mock_request.return_value, result)


### PR DESCRIPTION
Add basket-client support for the new Basket API for sending a recovery message.

Prereq: https://github.com/mozilla/basket/pull/75  (The basket update is needed to use the new call, but not to review or merge this request; it does nothing until called.)
