### PR TITLE
Add source_ip kwarg to subscribe and send_sms.

### DIFF
--- a/basket/base.py
+++ b/basket/base.py
@@ -145,19 +145,27 @@ def subscribe(email, newsletters, **kwargs):
                                   code=errors.BASKET_AUTH_ERROR)
         headers['x-api-key'] = api_key
 
+    source_ip = kwargs.pop('source_ip', None)
+    if source_ip:
+        headers['x-source-ip'] = source_ip
+
     return request('post', 'subscribe', data=kwargs, headers=headers)
 
 
-def send_sms(mobile_number, msg_name, optin=False):
+def send_sms(mobile_number, msg_name, optin=False, source_ip=None):
     """
     Send SMS message `msg_name` to `mobile_number` and optionally add the
     number to a list for future messages.
     """
+    headers = {}
+    if source_ip:
+        headers['x-source-ip'] = source_ip
+
     return request('post', 'subscribe_sms', data={
         'mobile_number': mobile_number,
         'msg_name': msg_name,
         'optin': 'Y' if optin else 'N',
-    })
+    }, headers=headers)
 
 
 def unsubscribe(token, email, newsletters=None, optout=False):

--- a/basket/tests.py
+++ b/basket/tests.py
@@ -6,7 +6,7 @@ from mock import ANY, Mock, patch
 
 from basket import (BasketException, confirm, confirm_email_change, debug_user,
                     errors, get_newsletters, lookup_user, request, send_recovery_message,
-                    start_email_change, subscribe,
+                    start_email_change, subscribe, send_sms,
                     unsubscribe, update_user, user)
 from basket.base import basket_url, get_env_or_setting, parse_response
 
@@ -467,3 +467,20 @@ class TestBasketClient(unittest.TestCase):
             result = confirm_email_change(change_key)
         request_call.assert_called_with('post', 'confirm-email-change', token=change_key)
         self.assertEqual(request_call.return_value, result)
+
+    @patch('basket.base.request')
+    def test_subscribe_source_ip(self, mock_request):
+        subscribe('dude@example.com', 'abiding-times', source_ip='1.1.1.1')
+        mock_request.assert_called_with('post', 'subscribe',
+                                        data={'email': 'dude@example.com',
+                                              'newsletters': 'abiding-times'},
+                                        headers={'x-source-ip': '1.1.1.1'})
+
+    @patch('basket.base.request')
+    def test_send_sms_source_ip(self, mock_request):
+        send_sms('5558675309', 'abide', source_ip='1.1.1.1')
+        mock_request.assert_called_with('post', 'subscribe_sms',
+                                        data={'mobile_number': '5558675309',
+                                              'msg_name': 'abide',
+                                              'optin': 'N'},
+                                        headers={'x-source-ip': '1.1.1.1'})

--- a/docs/change_log.rst
+++ b/docs/change_log.rst
@@ -8,6 +8,11 @@
 Change Log
 ======================
 
+v0.3.11
+-------
+
+* Add option to send the source IP to basket service for rate limiting purposes for the subscribe and send_sms functions.
+
 
 v0.3.10
 -------

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='basket-client',
-    version='0.3.10',
+    version='0.3.11',
     description="A Python client for Mozilla's basket service.",
     long_description=open('README.rst').read(),
     author='Michael Kelly and contributors',


### PR DESCRIPTION
Allows passing the source IP of the request to basket
for rate limiting purposes on the basket service side.