### PR TITLE
API updates and support for newer Pythons

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
       - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,27 +5,23 @@ exclude: >
   )
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-yaml
       - id: debug-statements
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.270"
+    rev: "v0.7.4"
     hooks:
       - id: ruff
-  - repo: https://github.com/psf/black
-    rev: 23.3.0
-    hooks:
-      - id: black
-        language_version: python3.9
+      - id: ruff-format
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 0.12.0
+    rev: v2.5.0
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.8.0
+    rev: v3.19.0
     hooks:
       - id: pyupgrade
-        args: [--py38-plus]
+        args: [--py39-plus]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ keywords = [
   "basket",
   "mozilla",
 ]
-license = {text = "BSD-3-Clause"}
+license = { text = "BSD-3-Clause" }
 maintainers = [
   { name = "Paul McLanahan" },
   { name = "Rob Hudson" },
@@ -20,7 +20,7 @@ maintainers = [
 authors = [
   { name = "Michael Kelly" },
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Web Environment",
@@ -29,10 +29,11 @@ classifiers = [
   "Natural Language :: English",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Communications",
   "Topic :: Software Development :: Libraries",
 ]
@@ -40,12 +41,11 @@ dynamic = [
   "version",
 ]
 dependencies = [
-  "requests<3.0.0",
+  "requests<3",
 ]
-[project.urls]
-Documentation = "https://github.com/mozilla/basket-client#readme"
-Issues = "https://github.com/mozilla/basket-client/issues"
-Source = "https://github.com/mozilla/basket-client"
+urls.Documentation = "https://github.com/mozilla/basket-client#readme"
+urls.Issues = "https://github.com/mozilla/basket-client/issues"
+urls.Source = "https://github.com/mozilla/basket-client"
 
 [tool.hatch.version]
 path = "src/basket/__init__.py"
@@ -61,7 +61,7 @@ include = [
 ]
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/basket"]
+packages = [ "src/basket" ]
 
 [tool.hatch.envs.test]
 dependencies = [
@@ -75,63 +75,41 @@ cov = "pytest --cov-config=pyproject.toml --cov=src/basket/ --cov-report term-mi
 
 [[tool.hatch.envs.test.matrix]]
 # Note: When changing these, also update the .github/workflows/test.yml file.
-python = ["3.8", "3.9", "3.10", "3.11"]
+python = [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
 
 [tool.hatch.envs.lint]
 detached = true
 dependencies = [
-  "black>=23.3.0",
-  "ruff>=0.0.275",
+  "ruff",
 ]
 [tool.hatch.envs.lint.scripts]
 check = [
-  "ruff {args:.}",
-  "black --check {args:.}",
+  "ruff check {args:.}",
 ]
 fix = [
   "ruff --fix {args:.}",
-  "black {args:.}",
   "style",
 ]
 all = [
   "style",
 ]
 
-[tool.black]
-line-length = 150
-target-version = ["py38"]
-include = '\.pyi?$'
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.tox
-  | \.venv
-  | _build
-  | build
-  | dist
-  | docs
-)/
-'''
-
 [tool.ruff]
-# Set what ruff should check for.
-# See https://beta.ruff.rs/docs/rules/ for a list of rules.
-select = [
-    "A", # flake8-builtin errors.
-    # "B", # bugbear errors
-    "E", # pycodestyle errors
-    "F", # pyflakes errors
-    "I", # import sorting
-    "Q", # flake8-quotes errors
-    "W", # pycodestyle warnings
-]
-line-length = 150  # To match black.
-target-version = "py38"
-extend-exclude = ["docs"]
+target-version = "py39"
+line-length = 150           # To match black.
+extend-exclude = [ "docs" ]
 
-[tool.ruff.isort]
-known-first-party = ["basket"]
+# See https://beta.ruff.rs/docs/rules/ for a list of rules.
+lint.select = [
+  "A", # flake8-builtin errors.
+  # "B", # bugbear errors
+  "E", # pycodestyle errors
+  "F", # pyflakes errors
+  "I", # import sorting
+  "Q", # flake8-quotes errors
+  "W", # pycodestyle warnings
+]
+lint.isort.known-first-party = [ "basket" ]
 
 [tool.coverage.run]
 branch = true

--- a/src/basket/__init__.py
+++ b/src/basket/__init__.py
@@ -1,16 +1,13 @@
 """A Python client for Mozilla's basket service."""
+
 from basket.base import (  # noqa: F401
     BasketException,
     BasketNetworkException,
     confirm,
-    confirm_email_change,
-    debug_user,
     get_newsletters,
     lookup_user,
     request,
     send_recovery_message,
-    send_sms,
-    start_email_change,
     subscribe,
     unsubscribe,
     update_user,


### PR DESCRIPTION
This PR updates the Basket client used by Bedrock to align with the newer Django Ninja APIs in Basket, as we're transitioning away from the older API versions. These changes ensure compatibility with the updated API endpoints for fetching newsletters.

Additionally, this PR updates the supported Python versions, as Python 3.8 is now unsupported, to ensure the codebase stays current and maintainable.